### PR TITLE
load routes from a configuration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
       "title": "Goto!",
       "description": "Go!",
       "mode": "view"
+    },
+    {
+      "name": "reload",
+      "title": "Reload configuration",
+      "description": "Reload the configuration file",
+      "mode": "no-view"
     }
   ],
   "preferences": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,17 @@
       "mode": "view"
     }
   ],
+  "preferences": [
+    {
+      "name": "goto_path",
+      "title": "Path to .goto.json file",
+      "label": "Path to .goto.json file",
+      "description": "Path to the .goto.json file",
+      "type": "textfield",
+      "required": true,
+      "default": "~/.goto.json"
+    }
+  ],
   "dependencies": {
     "@raycast/api": "^1.69.1"
   },

--- a/src/RouteList.tsx
+++ b/src/RouteList.tsx
@@ -63,8 +63,6 @@ function WildcardForm({ route }: RouteListItemProps) {
   }
 
   async function handleSubmit(values: Values) {
-    console.log(route, values);
-    console.log(route.url.replace("${0}", values.name));
     await open(route.url.replace("${0}", values.name));
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,18 @@
-import { routes } from "./routes";
+// import { routes } from "./routes";
+import { useEffect, useState } from "react";
 import { RouteList } from "./RouteList";
+import { getRoutes, Route } from "./routes";
 
 export default function Command() {
+  const [routes, setRoutes] = useState<Array<Route>>([]);
+
+  useEffect(() => {
+    async function fetchRoutes() {
+      const routes = await getRoutes();
+      setRoutes(routes);
+    }
+    fetchRoutes();
+  }, []);
+
   return <RouteList routes={routes} />;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,14 +2,23 @@
 import { useEffect, useState } from "react";
 import { RouteList } from "./RouteList";
 import { getRoutes, Route } from "./routes";
+import { showToast, Toast } from "@raycast/api";
 
 export default function Command() {
   const [routes, setRoutes] = useState<Array<Route>>([]);
 
   useEffect(() => {
     async function fetchRoutes() {
-      const routes = await getRoutes();
-      setRoutes(routes);
+      try {
+        const routes = await getRoutes();
+        setRoutes(routes);
+      } catch (error) {
+        await showToast({
+          title: "Failed to reload routes.",
+          style: Toast.Style.Failure,
+          message: error as string,
+        });
+      }
     }
     fetchRoutes();
   }, []);

--- a/src/reload.ts
+++ b/src/reload.ts
@@ -1,0 +1,12 @@
+import { showToast, Toast } from "@raycast/api";
+import { clearRoutes, getRoutes } from "./routes";
+
+export default async function Command() {
+  clearRoutes();
+  await getRoutes();
+  await showToast({
+    title: "Routes reloaded!",
+    style: Toast.Style.Success,
+    message: "Routes have been reloaded from configuration!",
+  });
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,4 +1,8 @@
 import { getPreferenceValues, Cache } from "@raycast/api";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
 export interface Route {
   name: string;
   url: string;
@@ -13,17 +17,24 @@ export async function getRoutes(): Promise<Array<Route>> {
   const cache = new Cache();
   const cached = cache.get("routes");
   if (cached) {
-    return Promise.resolve(JSON.parse("[]"));
+    return Promise.resolve(JSON.parse(cached));
   }
 
-  const preferences = getPreferenceValues<Preferences>();
-  // TODO: Fetch routes from preferences.goto_path
-  const routes: Array<Route> = [];
+  const routes = await loadRoutesFromFile();
   cache.set("routes", JSON.stringify(routes));
   return Promise.resolve(routes);
 }
 
+async function loadRoutesFromFile(): Promise<Array<Route>> {
+  console.log("Loading routes from file");
+  const preferences = getPreferenceValues<Preferences>();
+  const filePath = path.resolve(preferences.goto_path.replace(/^~(?=$|\/|\\)/, os.homedir()));
+
+  const fileContent = await fs.readFile(filePath, "utf-8");
+  return JSON.parse(fileContent) as Array<Route>;
+}
+
 export async function clearRoutes() {
   const cache = new Cache();
-  cache.clear();
+  cache.remove("routes");
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -37,6 +37,17 @@ export const routes: Array<Route> = [
   {
     name: "google",
     url: "https://google.com",
-    routes: [],
+    routes: [
+      {
+        name: "*",
+        url: "https://google.com?q=${0}",
+        routes: [],
+      },
+      {
+        name: "google",
+        url: "https://google.com",
+        routes: [],
+      },
+    ],
   },
 ];

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,53 +1,29 @@
+import { getPreferenceValues, Cache } from "@raycast/api";
 export interface Route {
   name: string;
   url: string;
   routes: Array<Route>;
 }
 
-export const routes: Array<Route> = [
-  {
-    name: "gh (GitHub)",
-    url: "https://github.com",
-    routes: [
-      {
-        name: "docs",
-        url: "https://github.com/camunda/camunda-docs",
-        routes: [
-          {
-            // gh docs issues
-            // gh docs pull/123
-            name: "*",
-            url: "https://github.com/camunda/camunda-docs/${0}",
-            routes: [],
-          },
-          {
-            name: "pulls",
-            url: "https://github.com/camunda/camunda-docs/pulls",
-            routes: [],
-          },
-        ],
-      },
-      {
-        name: "me",
-        url: "https://github.com/pepopowitz",
-        routes: [],
-      },
-    ],
-  },
-  {
-    name: "google",
-    url: "https://google.com",
-    routes: [
-      {
-        name: "*",
-        url: "https://google.com?q=${0}",
-        routes: [],
-      },
-      {
-        name: "google",
-        url: "https://google.com",
-        routes: [],
-      },
-    ],
-  },
-];
+interface Preferences {
+  goto_path: string;
+}
+
+export async function getRoutes(): Promise<Array<Route>> {
+  const cache = new Cache();
+  const cached = cache.get("routes");
+  if (cached) {
+    return Promise.resolve(JSON.parse("[]"));
+  }
+
+  const preferences = getPreferenceValues<Preferences>();
+  // TODO: Fetch routes from preferences.goto_path
+  const routes: Array<Route> = [];
+  cache.set("routes", JSON.stringify(routes));
+  return Promise.resolve(routes);
+}
+
+export async function clearRoutes() {
+  const cache = new Cache();
+  cache.clear();
+}


### PR DESCRIPTION
Finishes up the work from episode 7.

* Adds a preference for storing the path to the configuration file.
* Modifies the `routes.ts` file to include:
  * a `getRoutes` function, which returns the routes from a cache if they are populated, or loads them from the file system if the cache is empty.
  * a `clearRoutes` function, which removes the routes from the cache.
*  Modifies the `index` command to use `useEffect` to load the routes from `getRoutes`, and pass that into the tree renderer instead of a hardcoded value.
* Adds a `reload` command that calls `clearRoutes`, and then reloads the routes from the file system.

AND IT WORKS.

One thing that's missing is a template of a config file, so that someone would know how to create one. Maybe I'll add a sample one to the project.

Also, I never shoveled, so now I have to set my alarm for 6 to do it before the kids go to school.